### PR TITLE
Update logging of concurrent calls in GL

### DIFF
--- a/tap_quickbooks/quickbooks/reportstreams/GeneralLedgerReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/GeneralLedgerReport.py
@@ -88,7 +88,11 @@ class GeneralLedgerReport(QuickbooksStream):
             yield cleansed_row
 
     def concurrent_get(self, report_entity, params):
+        log_msg = f"Fetch GeneralLedgerReport for period {params['start_date']} to {params['end_date']}"
+        LOGGER.info(log_msg)
         response = self._get(report_entity, params)
+        LOGGER.info(f"COMPLETE: {log_msg}")
+        
         if "Unable to display more data. Please reduce the date range." in str(
             response
         ):
@@ -211,12 +215,6 @@ class GeneralLedgerReport(QuickbooksStream):
                 if len(requests_params) < max_requests and end_date < today:
                     continue
                 elif len(requests_params) == max_requests or end_date == today:
-                    [
-                        LOGGER.info(
-                            f"Fetch GeneralLedgerReport for period {x['start_date']} to {x['end_date']}"
-                        )
-                        for x in requests_params
-                    ]
                     with concurrent.futures.ThreadPoolExecutor(
                         max_workers=max_requests
                     ) as executor:


### PR DESCRIPTION
I tested the QuickBooks concurrent requests feature in my QA environment (with [this job](https://hotglue.com/env/qa.hotglue.saasgrid.com/jobs/uyPeK876t/logs/org_2Bp2IIwa1gH97CGpDljE0AHGfvW/flows/uyPeK876t/jobs/2023/11/1/01/21/Lowhu)). Looks good, but I wouldn't mind more granular logging with timestamps around true request and response times.

In the spirit of open source, I figured I'd just make the suggestion myself. I'm not sure how you guys test, so feel free to take this over.

The one thing I wasn't sure about was whether `LOGGER` context would be maintained within the thread, but my impression is that it will be on the basis of a short script I ran:
```
import concurrent.futures
import random
import time


def do_print(val: str):
    print(val)


def do_sleep():
    id = random.randint(0, 20)
    do_print(f"{id} starting to sleep: {time.time()}")
    time.sleep(3)
    do_print(f"{id} done sleeping: {time.time()}")


def main():
    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
        executor.map(lambda x: do_sleep(), range(6))


if __name__ == "__main__":
    main()
```
which had output
```
(venv) ➜  pandas-sandbox python3 test_concurrent.py
5 starting to sleep: 1698879002.306823
4 starting to sleep: 1698879002.306887
4 done sleeping: 1698879005.310208
5 done sleeping: 1698879005.310293
13 starting to sleep: 1698879005.3105762
20 starting to sleep: 1698879005.31064
13 done sleeping: 1698879008.31248
20 done sleeping: 1698879008.312551
8 starting to sleep: 1698879008.312741
19 starting to sleep: 1698879008.3128068
8 done sleeping: 1698879011.3143969
```
My assumption is that since `do_print` is captured accurately in the thread, so too will `LOGGER` in the original source code.

Again, feel free to just take this over / make edits yourself directly. Thanks!