### PR TITLE
Add Department fields to object definition schema

### DIFF
--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -555,7 +555,9 @@
     {"name": "KlassId", "type": "string"},
     {"name": "Class", "type": "string"},
     {"name": "ClassId", "type": "string"},
-    {"name": "Categories", "type": "array", "child_type": "string"}
+    {"name": "Categories", "type": "array", "child_type": "string"},
+    {"name": "Department", "type": "string"},
+    {"name": "DepartmentId", "type": "string"}
   ],
   "ARAgingSummaryReport": [
     {"name": "Customer", "type": "string"},


### PR DESCRIPTION
- Added "Department" and "DepartmentId" fields to the object definition schema in JSON.
- This update enhances the schema to support additional data related to departments, improving integration with QuickBooks data.