### PR TITLE
Add additional organizational fields to object_definition schema

### DIFF
--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -509,8 +509,17 @@
     {"name": "SupplierId", "type": "string"},
     {"name": "Supplier", "type": "string"},
     {"name": "Department", "type": "string"},
-    {"name": "DepartmentId", "type": "string"}
-
+    {"name": "DepartmentId", "type": "string"},
+    {"name": "Business", "type": "string"},
+    {"name": "BusinessId", "type": "string"},
+    {"name": "Division", "type": "string"},
+    {"name": "DivisionId", "type": "string"},
+    {"name": "Property", "type": "string"},
+    {"name": "PropertyId", "type": "string"},
+    {"name": "Store", "type": "string"},
+    {"name": "StoreId", "type": "string"},
+    {"name": "Territory", "type": "string"},
+    {"name": "TerritoryId", "type": "string"}
   ],
   "GeneralLedgerCashReport": [
     {"name": "Date", "type": "string"},
@@ -559,7 +568,17 @@
     {"name": "ClassId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"},
     {"name": "Department", "type": "string"},
-    {"name": "DepartmentId", "type": "string"}
+    {"name": "DepartmentId", "type": "string"},
+    {"name": "Business", "type": "string"},
+    {"name": "BusinessId", "type": "string"},
+    {"name": "Division", "type": "string"},
+    {"name": "DivisionId", "type": "string"},
+    {"name": "Property", "type": "string"},
+    {"name": "PropertyId", "type": "string"},
+    {"name": "Store", "type": "string"},
+    {"name": "StoreId", "type": "string"},
+    {"name": "Territory", "type": "string"},
+    {"name": "TerritoryId", "type": "string"}
   ],
   "ARAgingSummaryReport": [
     {"name": "Customer", "type": "string"},


### PR DESCRIPTION
Expanded object_definition schema to include new organizational fields such as Business, Division, Property, Store, and Territory, along with their corresponding ID fields for multiple reports