### PR TITLE
HGI-10879: stringify array fields as JSON and mask OAuth secrets in logs

### DIFF
--- a/tap_quickbooks/quickbooks/__init__.py
+++ b/tap_quickbooks/quickbooks/__init__.py
@@ -23,7 +23,7 @@ from tap_quickbooks.quickbooks.reportstreams.DailyCashFlowReport import DailyCas
 from tap_quickbooks.quickbooks.reportstreams.MonthlyCashFlowReport import MonthlyCashFlowReport
 from tap_quickbooks.quickbooks.reportstreams.TransactionListReport import TransactionListReport
 from tap_quickbooks.quickbooks.reportstreams.ARAgingSummaryReport import ARAgingSummaryReport
-from tap_quickbooks.util import save_api_usage
+from tap_quickbooks.util import mask_secret, redact_for_log, save_api_usage
 
 from tap_quickbooks.quickbooks.rest import Rest
 from tap_quickbooks.quickbooks.exceptions import (
@@ -417,7 +417,12 @@ class Quickbooks():
             LOGGER.info("Making %s request to %s with params: %s", http_method, url, params)
             resp = self.session.get(url, headers=headers, stream=stream, params=params)
         elif http_method == "POST":
-            LOGGER.info("Making %s request to %s with body %s", http_method, url, body)
+            LOGGER.info(
+                "Making %s request to %s with body %s",
+                http_method,
+                url,
+                redact_for_log(body),
+            )
             resp = self.session.post(url, headers=headers, data=body)
         else:
             raise TapQuickbooksException("Unsupported HTTP method")
@@ -476,7 +481,7 @@ class Quickbooks():
             self.access_token = auth['access_token']
 
             new_refresh_token = auth['refresh_token']
-            LOGGER.info(F"REFRESH TOKEN: {new_refresh_token}")
+            LOGGER.info("REFRESH TOKEN: %s", mask_secret(new_refresh_token))
 
             # persist access_token
             parser = argparse.ArgumentParser()
@@ -489,8 +494,8 @@ class Quickbooks():
 
             # Check if the refresh token is update, if so update the config file with new refresh token.
             if new_refresh_token != self.refresh_token:
-                LOGGER.info(f"Old refresh token [{self.refresh_token}] expired.")
-                LOGGER.info("New Refresh token: {}".format(new_refresh_token))
+                LOGGER.info("Old refresh token [%s] expired.", mask_secret(self.refresh_token))
+                LOGGER.info("New Refresh token: %s", mask_secret(new_refresh_token))
                 parser = argparse.ArgumentParser()
                 parser.add_argument('-c', '--config', help='Config file', required=True)
                 _args, unknown = parser.parse_known_args()

--- a/tap_quickbooks/sync.py
+++ b/tap_quickbooks/sync.py
@@ -28,6 +28,8 @@ def transform_data_hook(data, typ, schema):
 
         if not typ == 'object':
             result = json.dumps(data)
+    elif isinstance(data, list) and typ not in ('array', 'object'):
+        result = json.dumps(data)
 
     # Quickbooks can return the value '0.0' for integer typed fields. This
     # causes a schema violation. Convert it to '0' if schema['type'] has

--- a/tap_quickbooks/util.py
+++ b/tap_quickbooks/util.py
@@ -4,7 +4,9 @@ import threading
 import queue
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
+
+SECRET_LOG_KEYS = frozenset({"access_token", "client_secret", "refresh_token"})
 
 # Configurable log path
 LOG_FILE_PATH = Path(os.getenv("API_USAGE_LOG", "api_usage.jsonl"))
@@ -28,6 +30,29 @@ def get_sync_output_dir():
     if job_id:
         return f"/home/hotglue/{job_id}/sync-output"
     return "./sync-output"
+
+
+def mask_secret(value, visible=4):
+    """Return a log-safe token suffix, e.g. RT1-...xvcf -> ***xvcf."""
+    if value is None:
+        return value
+    secret = str(value)
+    if not secret:
+        return secret
+    if len(secret) <= visible:
+        return "***"
+    return f"***{secret[-visible:]}"
+
+
+def redact_for_log(data: Any) -> Any:
+    """Return a copy of request payloads with sensitive fields masked for logging."""
+    if not isinstance(data, Mapping):
+        return data
+    redacted = dict(data)
+    for key in SECRET_LOG_KEYS:
+        if key in redacted:
+            redacted[key] = mask_secret(redacted[key])
+    return redacted
 
 def _log_writer():
     """Background thread that writes logs to file."""

--- a/tests/test_secret_masking.py
+++ b/tests/test_secret_masking.py
@@ -1,0 +1,31 @@
+"""Tests for secret masking helpers."""
+
+from tap_quickbooks.util import mask_secret, redact_for_log
+
+
+def test_mask_secret_shows_suffix():
+    assert mask_secret("RT1-126-H0-1794170450b2w4wb69ey4diwpfxvcf") == "***xvcf"
+
+
+def test_mask_secret_handles_short_values():
+    assert mask_secret("abc") == "***"
+
+
+def test_redact_for_log_masks_oauth_body():
+    body = {
+        "grant_type": "refresh_token",
+        "client_id": "ABELs0U8bWJw6ZH4rNZS6y2Wai6qQlVUTtzQoS32OhW0x6AccX",
+        "client_secret": "LucG0PEhvuS1zyZT04Gwg0AuFARTD2kKfEsnoxdl",
+        "refresh_token": "RT1-126-H0-1794170450b2w4wb69ey4diwpfxvcf",
+    }
+
+    redacted = redact_for_log(body)
+
+    assert redacted["client_id"] == body["client_id"]
+    assert redacted["client_secret"] == "***oxdl"
+    assert redacted["refresh_token"] == "***xvcf"
+    assert body["client_secret"] == "LucG0PEhvuS1zyZT04Gwg0AuFARTD2kKfEsnoxdl"
+
+
+def test_redact_for_log_passes_through_non_mappings():
+    assert redact_for_log("plain") == "plain"

--- a/tests/test_secret_masking.py
+++ b/tests/test_secret_masking.py
@@ -4,7 +4,7 @@ from tap_quickbooks.util import mask_secret, redact_for_log
 
 
 def test_mask_secret_shows_suffix():
-    assert mask_secret("RT1-126-H0-1794170450b2w4wb69ey4diwpfxvcf") == "***xvcf"
+    assert mask_secret("test-refresh-token-abcdef") == "***cdef"
 
 
 def test_mask_secret_handles_short_values():
@@ -14,17 +14,17 @@ def test_mask_secret_handles_short_values():
 def test_redact_for_log_masks_oauth_body():
     body = {
         "grant_type": "refresh_token",
-        "client_id": "ABELs0U8bWJw6ZH4rNZS6y2Wai6qQlVUTtzQoS32OhW0x6AccX",
-        "client_secret": "LucG0PEhvuS1zyZT04Gwg0AuFARTD2kKfEsnoxdl",
-        "refresh_token": "RT1-126-H0-1794170450b2w4wb69ey4diwpfxvcf",
+        "client_id": "test-client-id-1234567890",
+        "client_secret": "test-client-secret-abcdefghij",
+        "refresh_token": "test-refresh-token-abcdef",
     }
 
     redacted = redact_for_log(body)
 
     assert redacted["client_id"] == body["client_id"]
-    assert redacted["client_secret"] == "***oxdl"
-    assert redacted["refresh_token"] == "***xvcf"
-    assert body["client_secret"] == "LucG0PEhvuS1zyZT04Gwg0AuFARTD2kKfEsnoxdl"
+    assert redacted["client_secret"] == "***ghij"
+    assert redacted["refresh_token"] == "***cdef"
+    assert body["client_secret"] == "test-client-secret-abcdefghij"
 
 
 def test_redact_for_log_passes_through_non_mappings():

--- a/tests/test_transform_data_hook.py
+++ b/tests/test_transform_data_hook.py
@@ -1,0 +1,48 @@
+"""Tests for transform_data_hook string coercion."""
+
+import json
+
+from singer import Transformer
+
+from tap_quickbooks.sync import transform_data_hook
+
+
+def _bill_schema():
+    string_type = {"type": ["string", "null"]}
+    return {
+        "type": "object",
+        "properties": {
+            "Line": string_type,
+            "CurrencyRef": string_type,
+            "VendorRef": string_type,
+        },
+    }
+
+
+def test_stringifies_list_fields_as_json():
+    record = {
+        "Line": [
+            {
+                "Id": "1",
+                "LineNum": 1,
+                "Amount": 12.0,
+                "DetailType": "ItemBasedExpenseLineDetail",
+            }
+        ],
+        "CurrencyRef": {"value": "USD", "name": "United States Dollar"},
+        "VendorRef": {"value": "146", "name": "BK Vendor 99900"},
+    }
+
+    with Transformer(pre_hook=transform_data_hook) as transformer:
+        result = transformer.transform(record, _bill_schema())
+
+    assert result["Line"].startswith('[{"')
+    assert result["Line"] == json.dumps(record["Line"])
+    assert result["CurrencyRef"] == json.dumps(record["CurrencyRef"])
+    assert result["VendorRef"] == json.dumps(record["VendorRef"])
+
+
+def test_does_not_stringify_lists_for_array_type():
+    line = [{"Id": "1", "Amount": 5.0}]
+    result = transform_data_hook(line, "array", {"type": ["array", "null"]})
+    assert result == line


### PR DESCRIPTION
Some QuickBooks fields come back as arrays but are typed as `string` in the tap schema. Singer was coercing those lists with `str()`, which produced Python repr output (`[{'Id': '1', ...`) instead of parseable JSON.

This PR also masks OAuth credentials in login logs. `client_secret` and `refresh_token` were being written in full to CloudWatch during token refresh.

- `transform_data_hook` now runs `json.dumps()` on lists when the target schema type is `string`, matching how dict refs like `CurrencyRef` are already handled
- Added `mask_secret` and `redact_for_log` helpers for log-safe OAuth values (`***xvcf` suffix)
- OAuth POST body logs and refresh token rotation logs use masked values; `client_id` stays visible for debugging

## Changed files
- **`tap_quickbooks/sync.py`**: JSON-stringify list values in `transform_data_hook` when schema type is not `array` or `object`
- **`tap_quickbooks/util.py`**: add `mask_secret` and `redact_for_log` helpers
- **`tap_quickbooks/quickbooks/__init__.py`**: redact OAuth secrets in POST request and login logs
- **`tests/test_transform_data_hook.py`**: cover list-to-string JSON coercion and array-type passthrough
- **`tests/test_secret_masking.py`**: cover secret masking helpers