### PR TITLE
HGI-11059: add AccountId to BalanceSheetReport stream

### DIFF
--- a/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
@@ -1,11 +1,18 @@
 import datetime
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, List
 
 import singer
+
 from tap_quickbooks.quickbooks.reportstreams.BaseReport import BaseReportStream
-from tap_quickbooks.sync import transform_data_hook
 
 LOGGER = singer.get_logger()
+
+
+def _col_value(cell):
+    """Return the string value from a ColData cell or plain scalar."""
+    if isinstance(cell, dict):
+        return cell.get("value")
+    return cell
 
 
 class BalanceSheetReport(BaseReportStream):
@@ -31,7 +38,7 @@ class BalanceSheetReport(BaseReportStream):
         if 'ColData' in list(row.keys()):
             # Write the row
             data = row.get("ColData")
-            values = [column.get("value") for column in data]
+            values = [column for column in data]
             categories_copy = categories.copy()
             values.append(categories_copy)
             values_copy = values.copy()
@@ -79,19 +86,22 @@ class BalanceSheetReport(BaseReportStream):
         # Zip columns and row data.
         for raw_row in output:
             row = dict(zip(columns, raw_row))
-            if not row.get("Total"):
+            if not _col_value(row.get("Total")):
                 # If a row is missing the amount, skip it
                 continue
 
             cleansed_row = {}
             for k, v in row.items():
-                if v == "":
+                if isinstance(v, dict):
+                    cleansed_row[k] = v.get("value")
+                    if v.get("id"):
+                        cleansed_row[f"{k}Id"] = v.get("id")
+                elif v == "":
                     continue
                 else:
-                    cleansed_row.update({k: v})
+                    cleansed_row[k] = v
 
-            cleansed_row["Total"] = float(row.get("Total"))
+            cleansed_row["Total"] = float(_col_value(row.get("Total")))
             cleansed_row["SyncTimestampUtc"] = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
 
             yield cleansed_row
-   

--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -459,6 +459,7 @@
   "BalanceSheetReport": [
     {"name": "Total", "type": "number"},
     {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"}
   ],
   "MonthlyBalanceSheetReport": [

--- a/tests/fixtures/streams/report/balance_sheet_response.json
+++ b/tests/fixtures/streams/report/balance_sheet_response.json
@@ -1,0 +1,47 @@
+{
+  "Columns": {
+    "Column": [
+      {"ColTitle": "", "ColType": "Account"},
+      {"ColTitle": "Total", "ColType": "Money"}
+    ]
+  },
+  "Rows": {
+    "Row": [
+      {
+        "Header": {"ColData": [{"value": "ASSETS"}]},
+        "Rows": {
+          "Row": [
+            {
+              "Header": {"ColData": [{"value": "Bank Accounts"}]},
+              "Rows": {
+                "Row": [
+                  {
+                    "ColData": [
+                      {"value": "Checking", "id": "35"},
+                      {"value": "100.00"}
+                    ],
+                    "type": "Data"
+                  },
+                  {
+                    "ColData": [
+                      {"value": "Savings", "id": "36"},
+                      {"value": "250.50"}
+                    ],
+                    "type": "Data"
+                  }
+                ]
+              }
+            },
+            {
+              "ColData": [
+                {"value": "Summary Row"},
+                {"value": ""}
+              ],
+              "type": "Data"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_balance_sheet_report.py
+++ b/tests/test_balance_sheet_report.py
@@ -1,0 +1,49 @@
+"""Unit tests for BalanceSheetReport account ID extraction."""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from tap_quickbooks.quickbooks.reportstreams.BalanceSheetReport import BalanceSheetReport
+
+
+@pytest.fixture
+def balance_sheet_report(mock_qb, load_report_fixture):
+    """BalanceSheetReport with mocked QB client."""
+    return BalanceSheetReport(
+        qb=mock_qb,
+        start_date=datetime.datetime(2024, 1, 1),
+        report_periods=None,
+    )
+
+
+class TestBalanceSheetReport:
+    def test_sync_emits_account_id_from_coldata(self, balance_sheet_report, load_report_fixture):
+        response = load_report_fixture("balance_sheet_response.json")
+        with patch.object(balance_sheet_report, "_get", return_value=response):
+            records = list(balance_sheet_report.sync(catalog_entry={}))
+
+        assert len(records) == 2
+        checking = next(r for r in records if r["Account"] == "Checking")
+        savings = next(r for r in records if r["Account"] == "Savings")
+
+        assert checking["AccountId"] == "35"
+        assert checking["Total"] == 100.0
+        assert checking["Categories"] == ["ASSETS", "Bank Accounts"]
+
+        assert savings["AccountId"] == "36"
+        assert savings["Total"] == 250.5
+
+    def test_sync_skips_rows_without_total(self, balance_sheet_report, load_report_fixture):
+        response = load_report_fixture("balance_sheet_response.json")
+        with patch.object(balance_sheet_report, "_get", return_value=response):
+            records = list(balance_sheet_report.sync(catalog_entry={}))
+
+        assert all(r["Account"] != "Summary Row" for r in records)
+
+    def test_object_definition_includes_account_id(self):
+        from tap_quickbooks.quickbooks import QB_OBJECT_DEFINITIONS
+
+        field_names = [f["name"] for f in QB_OBJECT_DEFINITIONS["BalanceSheetReport"]]
+        assert "AccountId" in field_names


### PR DESCRIPTION
The Balance Sheet report API returns an `id` on account ColData cells, but the tap only read `value` and the stream schema had no `AccountId` field.

This change adds `AccountId` to the `BalanceSheetReport` schema and extracts it from ColData using the same pattern as P&L report streams. Rows without an account id (e.g. computed Net Income) stay nullable.

Unit tests cover extraction from mocked report JSON. Sandbox discover/sync confirmed `AccountId` on real account rows.