### PR TITLE
HGI-11059: add AccountId to BalanceSheetReport stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tests/
 .secrets
 
 # Byte-compiled / optimized / DLL files

--- a/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
@@ -9,6 +9,14 @@ from tap_quickbooks.sync import transform_data_hook
 LOGGER = singer.get_logger()
 NUMBER_OF_PERIODS = 3
 
+
+def _col_value(cell):
+    """Return the string value from a ColData cell or plain scalar."""
+    if isinstance(cell, dict):
+        return cell.get("value")
+    return cell
+
+
 class BalanceSheetReport(BaseReportStream):
     tap_stream_id: ClassVar[str] = 'BalanceSheetReport'
     stream: ClassVar[str] = 'BalanceSheetReport'
@@ -32,7 +40,7 @@ class BalanceSheetReport(BaseReportStream):
         if 'ColData' in list(row.keys()):
             # Write the row
             data = row.get("ColData")
-            values = [column.get("value") for column in data]
+            values = [column for column in data]
             categories_copy = categories.copy()
             values.append(categories_copy)
             values_copy = values.copy()
@@ -80,18 +88,22 @@ class BalanceSheetReport(BaseReportStream):
         # Zip columns and row data.
         for raw_row in output:
             row = dict(zip(columns, raw_row))
-            if not row.get("Total"):
+            if not _col_value(row.get("Total")):
                 # If a row is missing the amount, skip it
                 continue
 
             cleansed_row = {}
             for k, v in row.items():
-                if v == "":
+                if isinstance(v, dict):
+                    cleansed_row[k] = v.get("value")
+                    if v.get("id"):
+                        cleansed_row[f"{k}Id"] = v.get("id")
+                elif v == "":
                     continue
                 else:
-                    cleansed_row.update({k: v})
+                    cleansed_row[k] = v
 
-            cleansed_row["Total"] = float(row.get("Total"))
+            cleansed_row["Total"] = float(_col_value(row.get("Total")))
             cleansed_row["SyncTimestampUtc"] = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
 
             yield cleansed_row

--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -422,6 +422,7 @@
   "BalanceSheetReport": [
     {"name": "Total", "type": "number"},
     {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"}
   ],
   "MonthlyBalanceSheetReport": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared pytest fixtures."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture():
+    """Load JSON fixture files."""
+    def _load(name: str):
+        if not name.endswith(".json"):
+            name = f"{name}.json"
+
+        fixture_path = FIXTURES_DIR / name
+
+        if not fixture_path.exists():
+            raise FileNotFoundError(f"Fixture not found: {fixture_path}")
+
+        with open(fixture_path) as f:
+            return json.load(f)
+    return _load
+
+
+@pytest.fixture
+def load_report_fixture(load_fixture):
+    """Load fixtures from streams/report/ directory."""
+    def _load(name: str):
+        return load_fixture(f"streams/report/{name}")
+    return _load
+
+
+@pytest.fixture
+def mock_qb():
+    """Mock QuickBooks client with defaults for full sync."""
+    qb = MagicMock()
+    qb.gl_basic_fields = True
+    qb.gl_full_sync = False
+    qb.gl_daily = False
+    qb.gl_weekly = False
+    return qb

--- a/tests/fixtures/streams/report/balance_sheet_response.json
+++ b/tests/fixtures/streams/report/balance_sheet_response.json
@@ -1,0 +1,47 @@
+{
+  "Columns": {
+    "Column": [
+      {"ColTitle": "", "ColType": "Account"},
+      {"ColTitle": "Total", "ColType": "Money"}
+    ]
+  },
+  "Rows": {
+    "Row": [
+      {
+        "Header": {"ColData": [{"value": "ASSETS"}]},
+        "Rows": {
+          "Row": [
+            {
+              "Header": {"ColData": [{"value": "Bank Accounts"}]},
+              "Rows": {
+                "Row": [
+                  {
+                    "ColData": [
+                      {"value": "Checking", "id": "35"},
+                      {"value": "100.00"}
+                    ],
+                    "type": "Data"
+                  },
+                  {
+                    "ColData": [
+                      {"value": "Savings", "id": "36"},
+                      {"value": "250.50"}
+                    ],
+                    "type": "Data"
+                  }
+                ]
+              }
+            },
+            {
+              "ColData": [
+                {"value": "Summary Row"},
+                {"value": ""}
+              ],
+              "type": "Data"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_balance_sheet_report.py
+++ b/tests/test_balance_sheet_report.py
@@ -1,0 +1,48 @@
+"""Unit tests for BalanceSheetReport account ID extraction."""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from tap_quickbooks.quickbooks.reportstreams.BalanceSheetReport import BalanceSheetReport
+
+
+@pytest.fixture
+def balance_sheet_report(mock_qb, load_report_fixture):
+    """BalanceSheetReport with mocked QB client."""
+    return BalanceSheetReport(
+        qb=mock_qb,
+        start_date=datetime.datetime(2024, 1, 1),
+    )
+
+
+class TestBalanceSheetReport:
+    def test_sync_emits_account_id_from_coldata(self, balance_sheet_report, load_report_fixture):
+        response = load_report_fixture("balance_sheet_response.json")
+        with patch.object(balance_sheet_report, "_get", return_value=response):
+            records = list(balance_sheet_report.sync(catalog_entry={}))
+
+        assert len(records) == 2
+        checking = next(r for r in records if r["Account"] == "Checking")
+        savings = next(r for r in records if r["Account"] == "Savings")
+
+        assert checking["AccountId"] == "35"
+        assert checking["Total"] == 100.0
+        assert checking["Categories"] == ["ASSETS", "Bank Accounts"]
+
+        assert savings["AccountId"] == "36"
+        assert savings["Total"] == 250.5
+
+    def test_sync_skips_rows_without_total(self, balance_sheet_report, load_report_fixture):
+        response = load_report_fixture("balance_sheet_response.json")
+        with patch.object(balance_sheet_report, "_get", return_value=response):
+            records = list(balance_sheet_report.sync(catalog_entry={}))
+
+        assert all(r["Account"] != "Summary Row" for r in records)
+
+    def test_object_definition_includes_account_id(self):
+        from tap_quickbooks.quickbooks import QB_OBJECT_DEFINITIONS
+
+        field_names = [f["name"] for f in QB_OBJECT_DEFINITIONS["BalanceSheetReport"]]
+        assert "AccountId" in field_names


### PR DESCRIPTION
Adds `AccountId` to `BalanceSheetReport` for downstream account mapping. The Balance Sheet API returns account ids on ColData cells, but the tap only read `value` and the stream schema had no `AccountId` field.

This backports the same extraction logic used on master: ColData dicts are preserved during row parsing and `id` is surfaced as `AccountId`. Rows without an account id (e.g. computed Net Income) stay nullable.

Also removes `tests/` from `.gitignore` so unit tests can live in the repo on this branch, matching master.