### PR TITLE
HGI-11059: add AccountId to MonthlyBalanceSheetReport stream

### DIFF
--- a/tap_quickbooks/quickbooks/reportstreams/MonthlyBalanceSheetReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/MonthlyBalanceSheetReport.py
@@ -1,13 +1,16 @@
 import datetime
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, List
 
 import singer
 
 from tap_quickbooks.quickbooks.reportstreams.BaseReport import BaseReportStream
-from tap_quickbooks.sync import transform_data_hook
 
 LOGGER = singer.get_logger()
 NUMBER_OF_PERIODS = 3
+
+# Metadata fields kept on the record; MonthlyTotal holds per-month amount columns only.
+_MONTHLY_TOTAL_SKIP = frozenset({"Account", "AccountId", "Categories", "SyncTimestampUtc"})
+
 
 class MonthlyBalanceSheetReport(BaseReportStream):
     tap_stream_id: ClassVar[str] = 'MonthlyBalanceSheetReport'
@@ -32,7 +35,7 @@ class MonthlyBalanceSheetReport(BaseReportStream):
         if 'ColData' in list(row.keys()):
             # Write the row
             data = row.get("ColData")
-            values = [column.get("value") for column in data]
+            values = [column for column in data]
             categories_copy = categories.copy()
             values.append(categories_copy)
             values_copy = values.copy()
@@ -92,18 +95,20 @@ class MonthlyBalanceSheetReport(BaseReportStream):
 
             cleansed_row = {}
             for k, v in row.items():
-                if v == "":
+                if isinstance(v, dict):
+                    cleansed_row[k] = v.get("value")
+                    if v.get("id"):
+                        cleansed_row[f"{k}Id"] = v.get("id")
+                elif v == "":
                     continue
                 else:
-                    cleansed_row.update({k: v})
+                    cleansed_row[k] = v
 
-            
             cleansed_row["SyncTimestampUtc"] = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
             monthly_total = []
-            for key,value in cleansed_row.items():
-                if key not in ['Account', 'Categories', 'SyncTimestampUtc']:
-                    monthly_total.append({key:value})
+            for key, value in cleansed_row.items():
+                if key not in _MONTHLY_TOTAL_SKIP:
+                    monthly_total.append({key: value})
             cleansed_row['MonthlyTotal'] = monthly_total
 
             yield cleansed_row
-       

--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -427,6 +427,7 @@
   ],
   "MonthlyBalanceSheetReport": [
     {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"},
     {"name": "MonthlyTotal", "type": "array", "child_type": "string"}
   ],
@@ -601,7 +602,8 @@
     {"name": "EndDate", "type": "string"},
     {"name": "Total", "type": "number"},
     {"name": "Categories", "type": "array", "child_type": "string"},
-    {"name": "Account", "type": "string"}
+    {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"}
   ],
   "TransactionListReport": [
     {"name": "Date", "type": "string"},

--- a/tests/fixtures/streams/report/monthly_balance_sheet_response.json
+++ b/tests/fixtures/streams/report/monthly_balance_sheet_response.json
@@ -1,0 +1,35 @@
+{
+  "Columns": {
+    "Column": [
+      {"ColTitle": "", "ColType": "Account"},
+      {"ColTitle": "Jan 2024", "ColType": "Money"},
+      {"ColTitle": "Feb 2024", "ColType": "Money"}
+    ]
+  },
+  "Rows": {
+    "Row": [
+      {
+        "Header": {"ColData": [{"value": "ASSETS"}]},
+        "Rows": {
+          "Row": [
+            {
+              "Header": {"ColData": [{"value": "Bank Accounts"}]},
+              "Rows": {
+                "Row": [
+                  {
+                    "ColData": [
+                      {"value": "Checking", "id": "35"},
+                      {"value": "100.00"},
+                      {"value": "110.00"}
+                    ],
+                    "type": "Data"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_monthly_balance_sheet_report.py
+++ b/tests/test_monthly_balance_sheet_report.py
@@ -1,0 +1,41 @@
+"""Unit tests for MonthlyBalanceSheetReport account ID extraction."""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from tap_quickbooks.quickbooks.reportstreams.MonthlyBalanceSheetReport import (
+    MonthlyBalanceSheetReport,
+)
+
+
+@pytest.fixture
+def monthly_balance_sheet_report(mock_qb):
+    """MonthlyBalanceSheetReport with mocked QB client."""
+    return MonthlyBalanceSheetReport(
+        qb=mock_qb,
+        start_date=datetime.datetime(2024, 1, 1),
+    )
+
+
+class TestMonthlyBalanceSheetReport:
+    def test_sync_emits_account_id_and_monthly_totals(self, monthly_balance_sheet_report, load_report_fixture):
+        response = load_report_fixture("monthly_balance_sheet_response.json")
+        with patch.object(monthly_balance_sheet_report, "_get", return_value=response):
+            records = list(monthly_balance_sheet_report.sync(catalog_entry={}))
+
+        assert len(records) == 1
+        record = records[0]
+        assert record["Account"] == "Checking"
+        assert record["AccountId"] == "35"
+        assert record["Categories"] == ["ASSETS", "Bank Accounts"]
+        assert record["MonthlyTotal"] == [{"Jan2024": "100.00"}, {"Feb2024": "110.00"}]
+
+    def test_object_definitions_include_account_id(self):
+        from tap_quickbooks.quickbooks import QB_OBJECT_DEFINITIONS
+
+        monthly_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["MonthlyBalanceSheetReport"]]
+        pnl_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["ProfitAndLossReport"]]
+        assert "AccountId" in monthly_fields
+        assert "AccountId" in pnl_fields


### PR DESCRIPTION
Adds `AccountId` to `MonthlyBalanceSheetReport` for downstream account mapping. The monthly balance sheet uses the same Balance Sheet API as `BalanceSheetReport`, where account ColData includes an `id`, but the tap only read `value`.

ColData dicts are preserved during row parsing and `id` is surfaced as `AccountId`. Metadata fields (`Account`, `AccountId`, `Categories`, `SyncTimestampUtc`) stay out of `MonthlyTotal`, which remains a list of per-month amount columns.

Also adds `AccountId` to the `ProfitAndLossReport` schema. That stream already extracted the field in code but discover did not list it.

Unit tests and sandbox discover/sync were run locally.