### PR TITLE
HGI-11059: add AccountId to monthly report streams

### DIFF
--- a/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BalanceSheetReport.py
@@ -3,16 +3,9 @@ from typing import ClassVar, List
 
 import singer
 
-from tap_quickbooks.quickbooks.reportstreams.BaseReport import BaseReportStream
+from tap_quickbooks.quickbooks.reportstreams.BaseReport import BaseReportStream, _col_field
 
 LOGGER = singer.get_logger()
-
-
-def _col_value(cell):
-    """Return the string value from a ColData cell or plain scalar."""
-    if isinstance(cell, dict):
-        return cell.get("value")
-    return cell
 
 
 class BalanceSheetReport(BaseReportStream):
@@ -86,7 +79,7 @@ class BalanceSheetReport(BaseReportStream):
         # Zip columns and row data.
         for raw_row in output:
             row = dict(zip(columns, raw_row))
-            if not _col_value(row.get("Total")):
+            if not _col_field(row.get("Total")):
                 # If a row is missing the amount, skip it
                 continue
 
@@ -101,7 +94,7 @@ class BalanceSheetReport(BaseReportStream):
                 else:
                     cleansed_row[k] = v
 
-            cleansed_row["Total"] = float(_col_value(row.get("Total")))
+            cleansed_row["Total"] = float(_col_field(row.get("Total")))
             cleansed_row["SyncTimestampUtc"] = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
 
             yield cleansed_row

--- a/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
@@ -11,6 +11,20 @@ from tap_quickbooks.quickbooks.rest_reports import QuickbooksStream, RetriableEx
 LOGGER = singer.get_logger()
 
 
+def _col_value(cell):
+    """Return the string value from a ColData cell or plain scalar."""
+    if isinstance(cell, dict):
+        return cell.get("value")
+    return cell
+
+
+def _account_id_from_cell(cell):
+    """Return account id from a ColData cell when present."""
+    if isinstance(cell, dict):
+        return cell.get("id")
+    return None
+
+
 def _is_fatal_including_504(e: requests.exceptions.RequestException) -> bool:
     """Fatal predicate for _get_504_fatal: same as is_fatal_code but also stops on 504.
 
@@ -109,7 +123,7 @@ class BaseReportStream(QuickbooksStream):
         row_group = row.get("Rows")
         if 'ColData' in list(row.keys()):
             data = row.get("ColData")
-            values = [column.get("value") for column in data]
+            values = [column for column in data]
             categories_copy = categories.copy()
             values.append(categories_copy)
             output.append(values.copy())
@@ -234,11 +248,11 @@ class BaseReportStream(QuickbooksStream):
             self._recursive_row_search(row, output, [])
 
         for raw_row in output:
-            # raw_row is [account_value, total_value, categories_list]
             if len(raw_row) < 3:
                 continue
-            account, total_val, categories = raw_row[0], raw_row[1], raw_row[-1]
-            if not total_val:
+            account_cell, total_val, categories = raw_row[0], raw_row[1], raw_row[-1]
+            account = _col_value(account_cell)
+            if not _col_value(total_val):
                 continue
             # Cash flow: skip rows with no parent category (e.g. "Cash at beginning
             # of period"). These are balance items, not flows, and the columnar API
@@ -253,13 +267,16 @@ class BaseReportStream(QuickbooksStream):
                     "Categories": categories,
                     "MonthlyTotal": [],
                 }
+                account_id = _account_id_from_cell(account_cell)
+                if account_id:
+                    merged[key]["AccountId"] = account_id
                 if track_total:
                     merged[key]["Total"] = 0.0
 
-            merged[key]["MonthlyTotal"].append({month_col: total_val})
+            merged[key]["MonthlyTotal"].append({month_col: _col_value(total_val)})
             if track_total:
                 try:
-                    merged[key]["Total"] += float(total_val)
+                    merged[key]["Total"] += float(_col_value(total_val))
                 except (ValueError, TypeError):
                     pass
 
@@ -267,11 +284,23 @@ class BaseReportStream(QuickbooksStream):
         """Accumulate one raw row into the cross-chunk merged dict."""
         row = dict(zip(columns, raw_row))
 
-        if track_total and not row.get("Total"):
+        if track_total and not _col_value(row.get("Total")):
             return
 
-        cleansed_row = {k: v for k, v in row.items() if v != ""}
-        exclude_keys = {"Account", "Categories", "Total"} if track_total else {"Account", "Categories"}
+        cleansed_row = {}
+        for k, v in row.items():
+            if isinstance(v, dict):
+                cleansed_row[k] = v.get("value")
+                if v.get("id"):
+                    cleansed_row[f"{k}Id"] = v.get("id")
+            elif v != "":
+                cleansed_row[k] = v
+
+        exclude_keys = (
+            {"Account", "AccountId", "Categories", "Total"}
+            if track_total
+            else {"Account", "AccountId", "Categories"}
+        )
         monthly_entries = [{k: v} for k, v in cleansed_row.items() if k not in exclude_keys]
 
         if not track_total and not monthly_entries:
@@ -284,12 +313,14 @@ class BaseReportStream(QuickbooksStream):
                 "Categories": cleansed_row.get("Categories"),
                 "MonthlyTotal": [],
             }
+            if cleansed_row.get("AccountId"):
+                merged[key]["AccountId"] = cleansed_row.get("AccountId")
             if track_total:
                 merged[key]["Total"] = 0.0
 
         if track_total:
             try:
-                merged[key]["Total"] += float(row.get("Total"))
+                merged[key]["Total"] += float(_col_value(row.get("Total")))
             except (ValueError, TypeError):
                 pass
         merged[key]["MonthlyTotal"].extend(monthly_entries)

--- a/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
@@ -290,9 +290,11 @@ class BaseReportStream(QuickbooksStream):
         cleansed_row = {}
         for k, v in row.items():
             if isinstance(v, dict):
-                cleansed_row[k] = v.get("value")
                 if v.get("id"):
                     cleansed_row[f"{k}Id"] = v.get("id")
+                value = v.get("value")
+                if value != "":
+                    cleansed_row[k] = value
             elif v != "":
                 cleansed_row[k] = v
 

--- a/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/BaseReport.py
@@ -11,18 +11,11 @@ from tap_quickbooks.quickbooks.rest_reports import QuickbooksStream, RetriableEx
 LOGGER = singer.get_logger()
 
 
-def _col_value(cell):
-    """Return the string value from a ColData cell or plain scalar."""
+def _col_field(cell, key="value"):
+    """Return a field from a ColData cell, or the scalar itself for value lookups."""
     if isinstance(cell, dict):
-        return cell.get("value")
-    return cell
-
-
-def _account_id_from_cell(cell):
-    """Return account id from a ColData cell when present."""
-    if isinstance(cell, dict):
-        return cell.get("id")
-    return None
+        return cell.get(key)
+    return cell if key == "value" else None
 
 
 def _is_fatal_including_504(e: requests.exceptions.RequestException) -> bool:
@@ -251,8 +244,8 @@ class BaseReportStream(QuickbooksStream):
             if len(raw_row) < 3:
                 continue
             account_cell, total_val, categories = raw_row[0], raw_row[1], raw_row[-1]
-            account = _col_value(account_cell)
-            if not _col_value(total_val):
+            account = _col_field(account_cell)
+            if not _col_field(total_val):
                 continue
             # Cash flow: skip rows with no parent category (e.g. "Cash at beginning
             # of period"). These are balance items, not flows, and the columnar API
@@ -267,16 +260,16 @@ class BaseReportStream(QuickbooksStream):
                     "Categories": categories,
                     "MonthlyTotal": [],
                 }
-                account_id = _account_id_from_cell(account_cell)
+                account_id = _col_field(account_cell, "id")
                 if account_id:
                     merged[key]["AccountId"] = account_id
                 if track_total:
                     merged[key]["Total"] = 0.0
 
-            merged[key]["MonthlyTotal"].append({month_col: _col_value(total_val)})
+            merged[key]["MonthlyTotal"].append({month_col: _col_field(total_val)})
             if track_total:
                 try:
-                    merged[key]["Total"] += float(_col_value(total_val))
+                    merged[key]["Total"] += float(_col_field(total_val))
                 except (ValueError, TypeError):
                     pass
 
@@ -284,7 +277,7 @@ class BaseReportStream(QuickbooksStream):
         """Accumulate one raw row into the cross-chunk merged dict."""
         row = dict(zip(columns, raw_row))
 
-        if track_total and not _col_value(row.get("Total")):
+        if track_total and not _col_field(row.get("Total")):
             return
 
         cleansed_row = {}
@@ -322,7 +315,7 @@ class BaseReportStream(QuickbooksStream):
 
         if track_total:
             try:
-                merged[key]["Total"] += float(_col_value(row.get("Total")))
+                merged[key]["Total"] += float(_col_field(row.get("Total")))
             except (ValueError, TypeError):
                 pass
         merged[key]["MonthlyTotal"].extend(monthly_entries)

--- a/tap_quickbooks/quickbooks/schemas/object_definition.json
+++ b/tap_quickbooks/quickbooks/schemas/object_definition.json
@@ -464,6 +464,7 @@
   ],
   "MonthlyBalanceSheetReport": [
     {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"},
     {"name": "MonthlyTotal", "type": "array", "child_type": "string"}
   ],
@@ -482,6 +483,7 @@
   "MonthlyCashFlowReport": [
     {"name": "Total", "type": "number"},
     {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"},
     {"name": "Categories", "type": "array", "child_type": "string"},
     {"name": "MonthlyTotal", "type": "array", "child_type": "string"}
 
@@ -641,7 +643,8 @@
   "ProfitAndLossReport": [
     {"name": "Total", "type": "number"},
     {"name": "Categories", "type": "array", "child_type": "string"},
-    {"name": "Account", "type": "string"}
+    {"name": "Account", "type": "string"},
+    {"name": "AccountId", "type": "string"}
   ],
   "TransactionListReport": [
     {"name": "Date", "type": "string"},

--- a/tests/test_balance_sheet_report.py
+++ b/tests/test_balance_sheet_report.py
@@ -45,5 +45,11 @@ class TestBalanceSheetReport:
     def test_object_definition_includes_account_id(self):
         from tap_quickbooks.quickbooks import QB_OBJECT_DEFINITIONS
 
-        field_names = [f["name"] for f in QB_OBJECT_DEFINITIONS["BalanceSheetReport"]]
-        assert "AccountId" in field_names
+        balance_sheet_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["BalanceSheetReport"]]
+        monthly_bs_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["MonthlyBalanceSheetReport"]]
+        monthly_cf_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["MonthlyCashFlowReport"]]
+        pnl_fields = [f["name"] for f in QB_OBJECT_DEFINITIONS["ProfitAndLossReport"]]
+        assert "AccountId" in balance_sheet_fields
+        assert "AccountId" in monthly_bs_fields
+        assert "AccountId" in monthly_cf_fields
+        assert "AccountId" in pnl_fields

--- a/tests/test_monthly_report_streams.py
+++ b/tests/test_monthly_report_streams.py
@@ -75,7 +75,7 @@ class TestRecursiveRowSearch:
                             "Row": [
                                 {
                                     "ColData": [
-                                        {"value": "Checking"},
+                                        {"value": "Checking", "id": "35"},
                                         {"value": "100.00"},
                                     ]
                                 }
@@ -88,7 +88,9 @@ class TestRecursiveRowSearch:
         categories = []
         output = []
         base_report._recursive_row_search(row, output, categories)
-        assert output == [["Checking", "100.00", ["Assets", "Bank Accounts"]]]
+        assert output == [
+            [{"value": "Checking", "id": "35"}, {"value": "100.00"}, ["Assets", "Bank Accounts"]]
+        ]
         assert categories == []
 
     @pytest.mark.parametrize("row", [{"Rows": {}}, {"Rows": None}])
@@ -150,6 +152,18 @@ class TestMergeRowIntoDict:
                 "Total": 300.0,
             }
         }
+
+    def test_merge_row_emits_account_id(self, base_report):
+        merged = {}
+        base_report._merge_row_into_dict(
+            [{"value": "Checking", "id": "35"}, "100.00", "", "100.00", ["Assets"]],
+            self.COLS,
+            merged,
+            track_total=False,
+        )
+        assert merged[("Checking", ("Assets",))]["AccountId"] == "35"
+        monthly_total = merged[("Checking", ("Assets",))]["MonthlyTotal"]
+        assert all("AccountId" not in entry for entry in monthly_total)
 
     @pytest.mark.parametrize(
         "raw_row,track_total",

--- a/tests/test_monthly_report_streams.py
+++ b/tests/test_monthly_report_streams.py
@@ -165,6 +165,18 @@ class TestMergeRowIntoDict:
         monthly_total = merged[("Checking", ("Assets",))]["MonthlyTotal"]
         assert all("AccountId" not in entry for entry in monthly_total)
 
+    def test_merge_row_skips_empty_structured_monthly_cells(self, base_report):
+        merged = {}
+        base_report._merge_row_into_dict(
+            [{"value": "Checking", "id": "35"}, {"value": ""}, "200.00", "200.00", ["Assets"]],
+            self.COLS,
+            merged,
+            track_total=False,
+        )
+        monthly_total = merged[("Checking", ("Assets",))]["MonthlyTotal"]
+        assert {"Jan2024": ""} not in monthly_total
+        assert monthly_total == [{"Feb2024": "200.00"}, {"Total": "200.00"}]
+
     @pytest.mark.parametrize(
         "raw_row,track_total",
         [


### PR DESCRIPTION
Adds `AccountId` to monthly report streams for downstream account mapping. `BalanceSheetReport` already had this from PR #210; monthly balance sheet and monthly cash flow still read only ColData `value` in the shared `BaseReport` monthly sync path.

`BaseReport` now preserves ColData dicts and surfaces `AccountId` on `MonthlyBalanceSheetReport` and `MonthlyCashFlowReport`. Metadata fields stay out of `MonthlyTotal`.

Also adds `AccountId` to the `ProfitAndLossReport` schema. That stream already extracted the field in code but discover did not list it.

Unit tests updated in `test_monthly_report_streams.py`. Sandbox discover/sync run for balance sheet, monthly balance sheet, monthly cash flow, and P&L.