### PR TITLE
HGI-10077: Reports API v2 report stream fixes (v1.5.x)

### DIFF
--- a/tap_quickbooks/quickbooks/reportstreams/ARAgingSummaryReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/ARAgingSummaryReport.py
@@ -21,7 +21,11 @@ class ARAgingSummaryReport(BaseReportStream):
             if column.get("ColTitle") == "" and column.get("ColType") == "Customer":
                 columns.append("Customer")
             else:
-                columns.append(column.get("ColTitle").replace(" ", ""))
+                normalized = column.get("ColTitle").replace(" ", "")
+                # v2 Reports API returns "91 AND OVER" in ALL CAPS; schema field is "91andover".
+                if normalized == "91ANDOVER":
+                    normalized = "91andover"
+                columns.append(normalized)
         return columns
 
     def sync(self, catalog_entry):

--- a/tap_quickbooks/quickbooks/reportstreams/DailyCashFlowReport.py
+++ b/tap_quickbooks/quickbooks/reportstreams/DailyCashFlowReport.py
@@ -1,16 +1,40 @@
 import datetime
 from datetime import timedelta
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, Iterator, List, Tuple
 
 import singer
 
 from tap_quickbooks.quickbooks.reportstreams.BaseReport import BaseReportStream
-from tap_quickbooks.sync import transform_data_hook
-from dateutil.relativedelta import relativedelta
-
 
 LOGGER = singer.get_logger()
 NUMBER_OF_PERIODS = 3
+
+# v2 caps summarize_column_by=Days at 200 daily columns per request; excess rolls into "Other".
+MAX_DAYS_PER_REQUEST = 200
+
+
+def _is_empty_or_zero_daily_value(value) -> bool:
+    """True when a day column has no activity (v1 omits these; v2 often sends 0.00)."""
+    if value is None or value == "":
+        return True
+    try:
+        return float(str(value).replace(",", "")) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
+def iter_date_chunks(
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+    max_days: int = MAX_DAYS_PER_REQUEST,
+) -> Iterator[Tuple[datetime.datetime, datetime.datetime]]:
+    """Yield inclusive (chunk_start, chunk_end) windows of at most max_days."""
+    chunk_start = start_date
+    while chunk_start <= end_date:
+        chunk_end = min(chunk_start + timedelta(days=max_days - 1), end_date)
+        yield chunk_start, chunk_end
+        chunk_start = chunk_end + timedelta(days=1)
+
 
 class DailyCashFlowReport(BaseReportStream):
     tap_stream_id: ClassVar[str] = 'DailyCashFlowReport'
@@ -38,8 +62,7 @@ class DailyCashFlowReport(BaseReportStream):
             values = [column.get("value") for column in data]
             categories_copy = categories.copy()
             values.append(categories_copy)
-            values_copy = values.copy()
-            output.append(values_copy)
+            output.append(values.copy())
         elif row_group is None or row_group == {}:
             pass
         else:
@@ -51,99 +74,66 @@ class DailyCashFlowReport(BaseReportStream):
                 self._recursive_row_search(row, output, categories)
             if header is not None:
                 categories.pop()
-    
 
-    def check_date_greater_than_months(self,date_obj):
-        # Get the current date
-        today = datetime.datetime.now()
+    def _parse_and_yield_rows(self, resp, columns):
+        row_array = resp.get("Rows", {}).get("Row")
+        if row_array is None:
+            return
 
-        # Calculate the difference in months between the date_obj and today
-        months_difference = (today.year - date_obj.year) * 12 + (today.month - date_obj.month)
+        output = []
+        categories = []
+        for row in row_array:
+            self._recursive_row_search(row, output, categories)
 
-        # Check if the number of months is greater than 33
-        return months_difference > 33
-    
-    def add_months(self, date_obj):
-        months_qty=33
-        # Calculate the new year and month after adding months
-        new_date_obj = date_obj + relativedelta(months=+months_qty)
-        return new_date_obj
-    
-    def correct_end_date(self, end_date, start_date, current_date):
-        if end_date > current_date:
-            # If end_date is greater than today then fetch report for yesterday.
-            end_date = current_date - timedelta(days=1)
-        if end_date <= start_date:
-            end_date = start_date
-        return end_date
-    
+        for raw_row in output:
+            row = dict(zip(columns, raw_row))
+            if not row.get("Total"):
+                continue
+
+            cleansed_row = {k: v for k, v in row.items() if v != ""}
+            cleansed_row["Total"] = float(row.get("Total"))
+            daily_total = [
+                {key: value}
+                for key, value in cleansed_row.items()
+                if key not in ("Account", "Categories", "SyncTimestampUtc", "Total")
+                and not _is_empty_or_zero_daily_value(value)
+            ]
+            cleansed_row["DailyTotal"] = daily_total
+            yield cleansed_row
+
     def sync(self, catalog_entry):
-        LOGGER.info(f"Starting full sync of CashFlow")
-        current_date = datetime.datetime.now() - timedelta(days=1)
-        #getting today's date as a datetime to avoid type errors
-        min_time = datetime.datetime.min.time()
-        today = datetime.date.today()
-        today_datetime = datetime.datetime.combine(today, min_time)
-        #-
-        end_date = today_datetime + datetime.timedelta(60)
+        LOGGER.info("Starting full sync of CashFlow")
+        current_date = datetime.datetime.now().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
+
         if self.qb.report_period_days:
-            start_date = today_datetime - datetime.timedelta(int(self.qb.report_period_days))
+            start_date = current_date - timedelta(days=int(self.qb.report_period_days))
         else:
-            start_date = self.start_date
-        start_date = start_date.replace(tzinfo=None)
+            start_date = self.start_date.replace(tzinfo=None)
 
-        if self.check_date_greater_than_months(start_date):
-            end_date = self.add_months(start_date)
-        end_date = self.correct_end_date(end_date,start_date,current_date)    
-        params = {
-            "start_date": start_date.strftime("%Y-%m-%d"),
-            "end_date": end_date.strftime("%Y-%m-%d"),
-            "accounting_method": "Accrual",
-            "summarize_column_by": "Days"
-        }
-        
-        while start_date.replace(tzinfo=None) <= current_date:
-            LOGGER.info(f"Fetch DailyCashFlow Report for period {params['start_date']} to {params['end_date']}")
-            resp = self._get(report_entity='CashFlow', params=params)
-
-            # Get column metadata.
+        merged = {}
+        for chunk_start, chunk_end in iter_date_chunks(start_date, current_date):
+            params = {
+                "start_date": chunk_start.strftime("%Y-%m-%d"),
+                "end_date": chunk_end.strftime("%Y-%m-%d"),
+                "accounting_method": "Accrual",
+                "summarize_column_by": "Days",
+            }
+            LOGGER.info(
+                f"Fetch DailyCashFlow Report for period {params['start_date']} to {params['end_date']}"
+            )
+            resp = self._get(report_entity="CashFlow", params=params)
             columns = self._get_column_metadata(resp)
+            for record in self._parse_and_yield_rows(resp, columns):
+                key = (record.get("Account"), tuple(record.get("Categories") or []))
+                if key not in merged:
+                    merged[key] = record
+                else:
+                    merged[key]["DailyTotal"].extend(record["DailyTotal"])
+                    merged[key]["Total"] += record["Total"]
 
-            # Recursively get row data.
-            row_group = resp.get("Rows")
-            row_array = row_group.get("Row")
-
-            if row_array is None:
-                return
-
-            output = []
-            categories = []
-            for row in row_array:
-                self._recursive_row_search(row, output, categories)
-
-            # Zip columns and row data.
-            for raw_row in output:
-                row = dict(zip(columns, raw_row))
-                if not row.get("Total"):
-                    # If a row is missing the amount, skip it
-                    continue
-
-                cleansed_row = {}
-                for k, v in row.items():
-                    if v == "":
-                        continue
-                    else:
-                        cleansed_row.update({k: v})
-
-                cleansed_row["Total"] = float(row.get("Total"))
-                cleansed_row["SyncTimestampUtc"] = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
-                daily_total = []
-                for key,value in cleansed_row.items():
-                    if key not in ['Account', 'Categories', 'SyncTimestampUtc', 'Total']:
-                        daily_total.append({key:value})
-                cleansed_row['DailyTotal'] = daily_total
-                start_date = end_date + timedelta(days=1)
-                end_date = self.add_months(start_date)
-                end_date = self.correct_end_date(end_date,start_date,current_date)  
-                yield cleansed_row
-       
+        sync_ts = singer.utils.strftime(singer.utils.now(), "%Y-%m-%dT%H:%M:%SZ")
+        for record in merged.values():
+            record["SyncTimestampUtc"] = sync_ts
+            yield record

--- a/tests/test_ar_aging_summary_report.py
+++ b/tests/test_ar_aging_summary_report.py
@@ -1,0 +1,55 @@
+"""Tests for ARAgingSummaryReport column normalization (HGI-10077 item 9)."""
+
+import datetime
+from unittest.mock import MagicMock
+
+from tap_quickbooks.quickbooks.reportstreams.ARAgingSummaryReport import ARAgingSummaryReport
+
+
+def _column_response(col_titles):
+    return {
+        "Columns": {
+            "Column": [
+                {"ColTitle": title, "ColType": "Customer" if title == "" else "Money"}
+                for title in col_titles
+            ]
+        }
+    }
+
+
+class TestARAgingSummaryColumnMetadata:
+    def test_v1_col_titles_unchanged(self):
+        stream = ARAgingSummaryReport(
+            qb=MagicMock(),
+            start_date=datetime.datetime(2025, 1, 1),
+        )
+        resp = _column_response(
+            ["", "Current", "1 - 30", "31 - 60", "61 - 90", "91 and over", "Total"]
+        )
+        assert stream._get_column_metadata(resp) == [
+            "Customer",
+            "Current",
+            "1-30",
+            "31-60",
+            "61-90",
+            "91andover",
+            "Total",
+        ]
+
+    def test_v2_all_caps_bucket_normalized(self):
+        stream = ARAgingSummaryReport(
+            qb=MagicMock(),
+            start_date=datetime.datetime(2025, 1, 1),
+        )
+        resp = _column_response(
+            ["", "Current", "1 - 30", "31 - 60", "61 - 90", "91 AND OVER", "Total"]
+        )
+        assert stream._get_column_metadata(resp) == [
+            "Customer",
+            "Current",
+            "1-30",
+            "31-60",
+            "61-90",
+            "91andover",
+            "Total",
+        ]

--- a/tests/test_daily_cash_flow_report.py
+++ b/tests/test_daily_cash_flow_report.py
@@ -1,0 +1,187 @@
+"""Tests for DailyCashFlowReport v2 day-column chunking."""
+
+import datetime
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tap_quickbooks.quickbooks.reportstreams.DailyCashFlowReport import (
+    MAX_DAYS_PER_REQUEST,
+    DailyCashFlowReport,
+    _is_empty_or_zero_daily_value,
+    iter_date_chunks,
+)
+
+
+class TestIsEmptyOrZeroDailyValue:
+    @pytest.mark.parametrize(
+        "value",
+        ["", None, "0", "0.0", "0.00", "0,00", 0, 0.0],
+    )
+    def test_zero_like_values(self, value):
+        assert _is_empty_or_zero_daily_value(value) is True
+
+    @pytest.mark.parametrize("value", ["1.00", "-1.00", "0.01"])
+    def test_non_zero_values(self, value):
+        assert _is_empty_or_zero_daily_value(value) is False
+
+
+class TestIterDateChunks:
+    def test_single_chunk_under_limit(self):
+        start = datetime.datetime(2026, 1, 1)
+        end = datetime.datetime(2026, 1, 31)
+        chunks = list(iter_date_chunks(start, end, max_days=200))
+        assert chunks == [(start, end)]
+
+    def test_exactly_max_days_is_one_chunk(self):
+        start = datetime.datetime(2026, 1, 1)
+        end = start + timedelta(days=MAX_DAYS_PER_REQUEST - 1)
+        chunks = list(iter_date_chunks(start, end, max_days=MAX_DAYS_PER_REQUEST))
+        assert len(chunks) == 1
+        assert chunks[0] == (start, end)
+
+    def test_max_plus_one_splits_into_two_chunks(self):
+        start = datetime.datetime(2026, 1, 1)
+        end = start + timedelta(days=MAX_DAYS_PER_REQUEST)
+        chunks = list(iter_date_chunks(start, end, max_days=MAX_DAYS_PER_REQUEST))
+        assert len(chunks) == 2
+        assert chunks[0][0] == start
+        assert chunks[0][1] == start + timedelta(days=MAX_DAYS_PER_REQUEST - 1)
+        assert chunks[1] == (chunks[0][1] + timedelta(days=1), end)
+
+    def test_year_long_range_produces_expected_chunk_count(self):
+        start = datetime.datetime(2025, 1, 1)
+        end = datetime.datetime(2025, 12, 31)
+        chunks = list(iter_date_chunks(start, end, max_days=200))
+        assert len(chunks) == 2
+        assert (chunks[0][1] - chunks[0][0]).days == 199
+        assert chunks[1][1] == end
+
+
+class TestDailyCashFlowReportSync:
+    @pytest.fixture
+    def report(self, mock_qb):
+        mock_qb.report_period_days = None
+        return DailyCashFlowReport(
+            qb=mock_qb,
+            start_date=datetime.datetime(2025, 1, 1),
+        )
+
+    @staticmethod
+    def _cashflow_response(day_labels):
+        return {
+            "Columns": {
+                "Column": [
+                    {"ColTitle": "", "ColType": "Account"},
+                    *[{"ColTitle": label, "ColType": "Money"} for label in day_labels],
+                    {"ColTitle": "Total", "ColType": "Money"},
+                ]
+            },
+            "Rows": {
+                "Row": [
+                    {
+                        "ColData": [
+                            {"value": "Net Income"},
+                            *[{"value": "1.00"} for _ in day_labels],
+                            {"value": "10.00"},
+                        ]
+                    }
+                ]
+            },
+        }
+
+    def test_sync_chunks_requests_and_merges_daily_columns(self, report):
+        calls = []
+
+        def fake_get(report_entity, params):
+            calls.append(params)
+            start = datetime.datetime.strptime(params["start_date"], "%Y-%m-%d")
+            end = datetime.datetime.strptime(params["end_date"], "%Y-%m-%d")
+            days = (end - start).days + 1
+            offset = (start - datetime.datetime(2025, 1, 1)).days
+            labels = [f"Day{offset + i}" for i in range(days)]
+            return self._cashflow_response(labels)
+
+        report._get = fake_get
+        current = datetime.datetime(2025, 12, 31)
+
+        with patch(
+            "tap_quickbooks.quickbooks.reportstreams.DailyCashFlowReport.datetime"
+        ) as mock_dt:
+            mock_dt.datetime.now.return_value = current + timedelta(days=1)
+            mock_dt.timedelta = timedelta
+            records = list(report.sync(catalog_entry=None))
+
+        assert len(calls) == 2
+        assert calls[0]["start_date"] == "2025-01-01"
+        assert calls[0]["end_date"] == "2025-07-19"
+        assert calls[1]["start_date"] == "2025-07-20"
+        assert calls[1]["end_date"] == "2025-12-31"
+        assert all(c["summarize_column_by"] == "Days" for c in calls)
+
+        assert len(records) == 1
+        day_keys = set()
+        for entry in records[0]["DailyTotal"]:
+            day_keys.update(entry.keys())
+        assert len(day_keys) == 365
+        assert "Other" not in day_keys
+
+    def test_parse_and_yield_rows_skips_zero_daily_values(self, report):
+        resp = {
+            "Columns": {
+                "Column": [
+                    {"ColTitle": "", "ColType": "Account"},
+                    {"ColTitle": "2026-01-01", "ColType": "Money"},
+                    {"ColTitle": "2026-01-02", "ColType": "Money"},
+                    {"ColTitle": "Total", "ColType": "Money"},
+                ]
+            },
+            "Rows": {
+                "Row": [
+                    {
+                        "ColData": [
+                            {"value": "Net Income"},
+                            {"value": "0.00"},
+                            {"value": "5.00"},
+                            {"value": "5.00"},
+                        ]
+                    }
+                ]
+            },
+        }
+        columns = report._get_column_metadata(resp)
+        records = list(report._parse_and_yield_rows(resp, columns))
+
+        assert len(records) == 1
+        assert records[0]["Total"] == 5.0
+        assert records[0]["DailyTotal"] == [{"2026-01-02": "5.00"}]
+
+    def test_parse_and_yield_rows_skips_missing_daily_values(self, report):
+        resp = {
+            "Columns": {
+                "Column": [
+                    {"ColTitle": "", "ColType": "Account"},
+                    {"ColTitle": "2026-01-01", "ColType": "Money"},
+                    {"ColTitle": "2026-01-02", "ColType": "Money"},
+                    {"ColTitle": "Total", "ColType": "Money"},
+                ]
+            },
+            "Rows": {
+                "Row": [
+                    {
+                        "ColData": [
+                            {"value": "Net Income"},
+                            {"value": None},
+                            {"value": "5.00"},
+                            {"value": "5.00"},
+                        ]
+                    }
+                ]
+            },
+        }
+        columns = report._get_column_metadata(resp)
+        records = list(report._parse_and_yield_rows(resp, columns))
+
+        assert len(records) == 1
+        assert records[0]["DailyTotal"] == [{"2026-01-02": "5.00"}]


### PR DESCRIPTION
Backport of the Reports API v2 fixes from master to `v1.5.x`. QuickBooks v2 changes how some report columns are returned. This PR updates two report streams so tap output stays correct under v2.

`DailyCashFlowReport` uses `summarize_column_by=Days`, which v2 caps at 200 columns per request. The stream now requests data in 200-day windows, merges `DailyTotal` across chunks into one record per account, and drops empty or zero day values so output stays sparse like v1. This also fixes a bug where sync loop params were never updated between iterations.

`ARAgingSummaryReport` maps the v2 aging bucket column `91 AND OVER` to the existing schema field `91andover`.